### PR TITLE
Fix multi-platform Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM node:26 AS buildjs
+FROM --platform=$BUILDPLATFORM node:26 AS buildjs
 WORKDIR /app
 COPY webapp .
 RUN npm ci
 RUN npm run build
 
-FROM golang:1.26 AS buildgo
+FROM --platform=$BUILDPLATFORM golang:1.26 AS buildgo
 WORKDIR /app
 COPY . .
 COPY --from=buildjs cmd/server/build cmd/server/build
-RUN CGO_ENABLED=0 go build -o ./build/simple-system-monitor ./cmd/server
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o ./build/simple-system-monitor ./cmd/server
 
 FROM alpine:3
 WORKDIR /app


### PR DESCRIPTION
## Summary
- run Docker build stages on the build platform
- cross-compile the Go binary for Docker Buildx target platforms
- keep the existing multi-platform CI setting able to produce linux/amd64 and linux/arm64 images

## Test
- docker buildx build --platform linux/amd64 -t simple-system-monitor:pr-amd64 --load .
- docker image inspect simple-system-monitor:pr-amd64 --format '{{.Os}}/{{.Architecture}} {{.Config.Entrypoint}}'